### PR TITLE
Remove insecure dependency

### DIFF
--- a/.github/workflows/jarvis-code.yml
+++ b/.github/workflows/jarvis-code.yml
@@ -25,9 +25,5 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Check GitHub Status
-        # Source of GitHub Action in line 30: 
-        # https://github.com/dduzgun-security/secure-code-game-action
-        uses: dduzgun-security/secure-code-game-action@dc70b85ad674f6e93657401f3933622870372093 # v1.0
-        with:
-          who-to-greet: "Jarvis, obviously ..."
-          get-token: "token-4db56ee8-dbec-46f3-96f5-32247695ab9b"
+        run: |
+          curl https://www.githubstatus.com/api/v2/status.json | python3 -m json.tool


### PR DESCRIPTION
Replace insecure actions dependency (dduzgun-security/secure-code-game-action)[https://github.com/dduzgun-security/secure-code-game-action] to retrieve GitHub Status with an API call via cURL.